### PR TITLE
Add testing instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,19 @@ Simple Express-based prototype for call center gamification.
 npm install
 npm start
 ```
+
+## Testing
+
+Run the test suite:
+
+```bash
+npm test
+```
+
+No additional environment variables are required. The server will use `PORT` if set, but tests run against the in-memory app.
+
+To automatically rerun tests on file changes (Node 18+):
+
+```bash
+npm test -- --watch
+```


### PR DESCRIPTION
## Summary
- document how to run the test suite and watch mode in the README
- note optional PORT environment variable for server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5e25db5788325bd8a597cfdf6337c