### PR TITLE
Avoid duplicate call scoring

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -19,7 +19,8 @@ const Agent = sequelize.define('Agent', {
 const Call = sequelize.define('Call', {
   externalId: {
     type: DataTypes.STRING,
-    allowNull: true
+    allowNull: true,
+    unique: true,
   },
   points: DataTypes.INTEGER
 });

--- a/src/migrations/001-add-unique-externalId.js
+++ b/src/migrations/001-add-unique-externalId.js
@@ -1,0 +1,21 @@
+const { sequelize } = require('../db');
+
+async function up() {
+  const qi = sequelize.getQueryInterface();
+  await qi.addConstraint('Calls', {
+    fields: ['externalId'],
+    type: 'unique',
+    name: 'calls_externalId_unique',
+  });
+}
+
+up()
+  .then(() => {
+    console.log('Migration completed');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('Migration failed', err);
+    process.exit(1);
+  });
+

--- a/src/server.js
+++ b/src/server.js
@@ -1,36 +1,34 @@
 const express = require('express');
- codex/add-validation-for-call-parameters
 const Joi = require('joi');
-
 const crypto = require('crypto');
- main
+
 const { computePoints } = require('./gamification');
 const { Agent, Call, initDb } = require('./db');
 
 const app = express();
+
 // Capture the raw body so we can verify the signature
-app.use(express.json({
-  verify: (req, res, buf) => {
-    req.rawBody = buf.toString();
-  }
-}));
+app.use(
+  express.json({
+    verify: (req, res, buf) => {
+      req.rawBody = buf.toString();
+    },
+  })
+);
 
 // validation schema
 const payloadSchema = Joi.object({
   call: Joi.object({
     duration: Joi.number().min(0),
-    response_time: Joi.number().min(0)
+    response_time: Joi.number().min(0),
   }).unknown(),
   scored_call: Joi.object({
-    percentage: Joi.number().min(0).max(100)
-  }).unknown()
+    percentage: Joi.number().min(0).max(100),
+  }).unknown(),
 }).unknown();
 
 // Webhook endpoint
- codex/introduce-database-layer-with-orm
 app.post('/api/webhooks/calldrip', async (req, res) => {
-
-app.post('/api/webhooks/calldrip', (req, res) => {
   const secret = process.env.WEBHOOK_SECRET || '';
   const receivedSig = req.get('X-Signature') || '';
   const expectedSig = crypto
@@ -40,7 +38,7 @@ app.post('/api/webhooks/calldrip', (req, res) => {
   if (receivedSig !== expectedSig) {
     return res.status(401).json({ error: 'Invalid signature' });
   }
- main
+
   const payload = req.body || {};
   const agentPayload = payload.agent || {};
   const agentId = agentPayload.id;
@@ -48,35 +46,34 @@ app.post('/api/webhooks/calldrip', (req, res) => {
     return res.status(400).json({ error: 'Missing agent.id' });
   }
 
- codex/add-validation-for-call-parameters
   const { error } = payloadSchema.validate(payload);
   if (error) {
     return res.status(400).json({ error: error.message });
   }
 
-  // create or update agent
-  const a = agents.get(agentId) || {
-    id: agentId,
-    firstName: agent.first_name || '',
-    lastName: agent.last_name || '',
-    totalPoints: 0
-  };
-
+  // create agent if needed
   let agent = await Agent.findByPk(agentId);
   if (!agent) {
     agent = await Agent.create({
       id: agentId,
       firstName: agentPayload.first_name || '',
       lastName: agentPayload.last_name || '',
-      totalPoints: 0
+      totalPoints: 0,
     });
   }
 
- main
+  const externalId = payload.call?.id ?? null;
+  if (externalId) {
+    const existing = await Call.findOne({ where: { externalId } });
+    if (existing) {
+      return res.status(200).json({ pointsAwarded: 0 });
+    }
+  }
+
   const points = computePoints(payload);
-  agent.totalPoints += points;
-  await agent.save();
-  await Call.create({ externalId: payload.call?.id ?? null, agentId, points });
+  await Agent.increment('totalPoints', { by: points, where: { id: agentId } });
+  await Call.create({ externalId, agentId, points });
+
   res.json({ pointsAwarded: points });
 });
 
@@ -107,3 +104,4 @@ if (require.main === module) {
 }
 
 module.exports = { app, initDb };
+

--- a/test/duplicate-call.test.js
+++ b/test/duplicate-call.test.js
@@ -1,0 +1,48 @@
+const test = require('node:test');
+const assert = require('assert/strict');
+const request = require('supertest');
+const crypto = require('crypto');
+
+process.env.DATABASE_URL = 'sqlite::memory:';
+process.env.WEBHOOK_SECRET = 'testsecret';
+
+const { app, initDb } = require('../src/server');
+const { Agent, Call } = require('../src/db');
+const { computePoints } = require('../src/gamification');
+
+test('ignores duplicate calls with same externalId', async () => {
+  await initDb();
+
+  const payload = {
+    agent: { id: 'dup-agent', first_name: 'Dup', last_name: 'Agent' },
+    call: { id: 'call-123', duration: 120, response_time: 10 },
+    scored_call: { percentage: 80, opportunity: true },
+  };
+
+  const signature = crypto
+    .createHmac('sha256', process.env.WEBHOOK_SECRET)
+    .update(JSON.stringify(payload))
+    .digest('hex');
+
+  await request(app)
+    .post('/api/webhooks/calldrip')
+    .set('X-Signature', signature)
+    .send(payload)
+    .expect(200);
+
+  const second = await request(app)
+    .post('/api/webhooks/calldrip')
+    .set('X-Signature', signature)
+    .send(payload)
+    .expect(200);
+
+  assert.equal(second.body.pointsAwarded, 0);
+
+  const agent = await Agent.findByPk('dup-agent');
+  const expected = computePoints(payload);
+  assert.equal(agent.totalPoints, expected);
+
+  const calls = await Call.count();
+  assert.equal(calls, 1);
+});
+


### PR DESCRIPTION
## Summary
- skip scoring and Call creation when an existing Call with the same externalId is found
- use `Agent.increment` and add unique constraint on `Call.externalId`
- include migration and test covering duplicate call handling

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e66d7e888325a4a6825625876b9b