### PR TITLE
Add basic frontend and serve static assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ npm install
 npm start
 ```
 
+The server will serve the static frontend from `frontend/`. After starting,
+open [http://localhost:3000](http://localhost:3000) to view the leaderboard
+and agent dashboards.
+
 ## Testing
 
 Run the test suite:
@@ -32,3 +36,10 @@ To automatically rerun tests on file changes (Node 18+):
 ```bash
 npm test -- --watch
 ```
+
+## Frontend Build
+
+The frontend lives in the `frontend/` directory and is plain HTML, CSS, and
+JavaScript. No compilation step is required; the files are served directly by
+Express. To make changes, edit the files in `frontend/` and restart the server
+if necessary.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,28 @@
+async function loadLeaderboard() {
+  const res = await fetch('/api/leaderboard');
+  const data = await res.json();
+  const tbody = document.querySelector('#leaderboard tbody');
+  tbody.innerHTML = '';
+  data.leaderboard.forEach((agent) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${agent.firstName} ${agent.lastName}</td><td>${agent.totalPoints}</td>`;
+    tr.addEventListener('click', () => loadAgent(agent.id));
+    tbody.appendChild(tr);
+  });
+}
+
+async function loadAgent(agentId) {
+  const res = await fetch(`/api/agents/${agentId}/dashboard`);
+  const data = await res.json();
+  const container = document.getElementById('agent-details');
+  const calls = data.calls
+    .map((c) => `<li>${c.externalId}: ${c.points}</li>`)
+    .join('');
+  container.innerHTML = `
+    <h3>${data.agent.firstName} ${data.agent.lastName}</h3>
+    <p>Total Points: ${data.agent.totalPoints}</p>
+    <ul>${calls}</ul>
+  `;
+}
+
+loadLeaderboard();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>BDC Leaderboard</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <h1>Leaderboard</h1>
+    <table id="leaderboard">
+      <thead>
+        <tr><th>Agent</th><th>Points</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+
+    <h2>Agent Details</h2>
+    <div id="agent-details"></div>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,19 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+th, td {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+
+tr:hover {
+  background-color: #f1f1f1;
+  cursor: pointer;
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const Joi = require('joi');
 const crypto = require('crypto');
+const path = require('path');
 const { computePoints } = require('./gamification');
 const { Agent, Call, initDb } = require('./db');
 
 const app = express();
+app.use(express.static(path.join(__dirname, '../frontend')));
 
 // Capture the raw body so we can verify the signature
 app.use(


### PR DESCRIPTION
## Summary
- Add static frontend with leaderboard table and agent detail views.
- Serve frontend through Express using `express.static`.
- Document frontend build and usage instructions in README.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f46d7da48325a73001031e00b62f