### PR TITLE
Add pagination to leaderboard endpoint

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -86,10 +86,35 @@ app.post('/api/webhooks/calldrip', async (req, res) => {
 
 // Leaderboard endpoint
 app.get('/api/leaderboard', async (req, res) => {
-  const leaderboard = await Agent.findAll({
-    order: [['totalPoints', 'DESC']],
-  });
-  res.json({ leaderboard });
+  let { limit, offset, page } = req.query;
+  limit = limit !== undefined ? parseInt(limit, 10) : undefined;
+  if (Number.isNaN(limit) || limit <= 0) {
+    limit = undefined;
+  }
+
+  if (page !== undefined && offset === undefined && limit !== undefined) {
+    const pageNum = parseInt(page, 10);
+    if (!Number.isNaN(pageNum) && pageNum > 0) {
+      offset = (pageNum - 1) * limit;
+    }
+  } else if (offset !== undefined) {
+    offset = parseInt(offset, 10);
+    if (Number.isNaN(offset) || offset < 0) {
+      offset = undefined;
+    }
+  }
+
+  const [leaderboard, totalCount] = await Promise.all([
+    Agent.findAll({
+      order: [['totalPoints', 'DESC']],
+      limit,
+      offset,
+    }),
+    Agent.count(),
+  ]);
+
+  const pageSize = limit || leaderboard.length;
+  res.json({ leaderboard, pagination: { totalCount, pageSize } });
 });
 
 // Agent dashboard endpoint

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,6 +1,6 @@
 const request = require('supertest');
 const { app, initDb } = require('../src/server');
-const { sequelize } = require('../src/db');
+const { sequelize, Agent } = require('../src/db');
 const { computePoints } = require('../src/gamification');
 const crypto = require('crypto');
 
@@ -105,4 +105,46 @@ test('numeric agent id is rejected', async () => {
     .set('X-Signature', sign(payload))
     .send(payload)
     .expect(400);
+});
+
+test('leaderboard supports limit and offset', async () => {
+  for (let i = 1; i <= 5; i++) {
+    await Agent.create({
+      id: `agent${i}`,
+      firstName: '',
+      lastName: '',
+      totalPoints: 6 - i,
+    });
+  }
+
+  const res = await request(app)
+    .get('/api/leaderboard?limit=2&offset=2')
+    .expect(200);
+  expect(res.body.leaderboard.map((a) => a.id)).toEqual([
+    'agent3',
+    'agent4',
+  ]);
+  expect(res.body.pagination.totalCount).toBe(5);
+  expect(res.body.pagination.pageSize).toBe(2);
+});
+
+test('leaderboard supports page parameter', async () => {
+  for (let i = 1; i <= 5; i++) {
+    await Agent.create({
+      id: `agent${i}`,
+      firstName: '',
+      lastName: '',
+      totalPoints: 6 - i,
+    });
+  }
+
+  const res = await request(app)
+    .get('/api/leaderboard?limit=2&page=2')
+    .expect(200);
+  expect(res.body.leaderboard.map((a) => a.id)).toEqual([
+    'agent3',
+    'agent4',
+  ]);
+  expect(res.body.pagination.totalCount).toBe(5);
+  expect(res.body.pagination.pageSize).toBe(2);
 });


### PR DESCRIPTION
## Summary
- parse `limit`, `offset`, and `page` query params for the leaderboard API
- return pagination metadata including total count and page size
- add tests for pagination using limit/offset and page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5f465b9908325afb77d6afc3d87e9