### PR TITLE
Add tests for gamification edge cases

### DIFF
--- a/test/gamification.test.js
+++ b/test/gamification.test.js
@@ -1,0 +1,26 @@
+const { computePoints } = require('../src/gamification');
+
+describe('computePoints edge cases', () => {
+  test('returns 0 when no fields are provided', () => {
+    expect(computePoints({})).toBe(0);
+  });
+
+  test('handles boundary values for duration, response time and score', () => {
+    const insideThreshold = {
+      call: { duration: 60, response_time: 29 },
+      scored_call: { percentage: 55 },
+    };
+    expect(computePoints(insideThreshold)).toBe(1 + 5 + 6);
+
+    const atThreshold = {
+      call: { duration: 59, response_time: 30 },
+      scored_call: { percentage: 54 },
+    };
+    expect(computePoints(atThreshold)).toBe(5);
+  });
+
+  test('adds opportunity bonus when flag is true', () => {
+    expect(computePoints({ scored_call: { opportunity: true } })).toBe(10);
+    expect(computePoints({ scored_call: { opportunity: false } })).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- test computePoints with empty payload and boundary values
- verify opportunity bonus handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5fc9da1ec83259550df8cd0d6c2c5