### PR TITLE
Handle fetch errors and auto refresh leaderboard

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,28 +1,49 @@
+const errorContainer = document.getElementById('error');
+
+function showError(message) {
+  if (errorContainer) {
+    errorContainer.textContent = message;
+  }
+}
+
 async function loadLeaderboard() {
-  const res = await fetch('/api/leaderboard');
-  const data = await res.json();
-  const tbody = document.querySelector('#leaderboard tbody');
-  tbody.innerHTML = '';
-  data.leaderboard.forEach((agent) => {
-    const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${agent.firstName} ${agent.lastName}</td><td>${agent.totalPoints}</td>`;
-    tr.addEventListener('click', () => loadAgent(agent.id));
-    tbody.appendChild(tr);
-  });
+  try {
+    const res = await fetch('/api/leaderboard');
+    if (!res.ok) throw new Error('Failed to fetch leaderboard');
+    const data = await res.json();
+    const tbody = document.querySelector('#leaderboard tbody');
+    tbody.innerHTML = '';
+    data.leaderboard.forEach((agent) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${agent.firstName} ${agent.lastName}</td><td>${agent.totalPoints}</td>`;
+      tr.addEventListener('click', () => loadAgent(agent.id));
+      tbody.appendChild(tr);
+    });
+    if (errorContainer) errorContainer.textContent = '';
+  } catch (err) {
+    showError('Error loading leaderboard');
+  }
 }
 
 async function loadAgent(agentId) {
-  const res = await fetch(`/api/agents/${agentId}/dashboard`);
-  const data = await res.json();
-  const container = document.getElementById('agent-details');
-  const calls = data.calls
-    .map((c) => `<li>${c.externalId}: ${c.points}</li>`)
-    .join('');
-  container.innerHTML = `
-    <h3>${data.agent.firstName} ${data.agent.lastName}</h3>
-    <p>Total Points: ${data.agent.totalPoints}</p>
-    <ul>${calls}</ul>
-  `;
+  try {
+    const res = await fetch(`/api/agents/${agentId}/dashboard`);
+    if (!res.ok) throw new Error('Failed to fetch agent');
+    const data = await res.json();
+    const container = document.getElementById('agent-details');
+    const calls = data.calls
+      .map((c) => `<li>${c.externalId}: ${c.points}</li>`)
+      .join('');
+    container.innerHTML = `
+      <h3>${data.agent.firstName} ${data.agent.lastName}</h3>
+      <p>Total Points: ${data.agent.totalPoints}</p>
+      <ul>${calls}</ul>
+    `;
+    if (errorContainer) errorContainer.textContent = '';
+  } catch (err) {
+    showError('Error loading agent details');
+  }
 }
 
 loadLeaderboard();
+setInterval(loadLeaderboard, 60000);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,7 @@
   </head>
   <body>
     <h1>Leaderboard</h1>
+    <div id="error"></div>
     <table id="leaderboard">
       <thead>
         <tr><th>Agent</th><th>Points</th></tr>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -17,3 +17,8 @@ tr:hover {
   background-color: #f1f1f1;
   cursor: pointer;
 }
+
+#error {
+  color: red;
+  margin: 10px 0;
+}


### PR DESCRIPTION
## Summary
- wrap leaderboard and agent fetch calls in try/catch with a shared error handler
- show errors in the page via a new `#error` element
- refresh the leaderboard automatically every 60 seconds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5fca08abc83258c2570a3f1841a6a